### PR TITLE
Add ability to access output from FunctionsController

### DIFF
--- a/Solutions/Corvus.SpecFlow.Extensions.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions.Demo/AzureFunctionsTesting/DemoFunctionPerFeatureHooks.cs
@@ -25,7 +25,7 @@ namespace Corvus.SpecFlow.Extensions.Demo.AzureFunctionsTesting
                 "netcoreapp3.1");
         }
 
-        [BeforeScenario("usingDemoFunctionPerFeatureWithAdditionalConfiguration")]
+        [BeforeFeature("usingDemoFunctionPerFeatureWithAdditionalConfiguration")]
         public static Task StartFunctionWithAdditionalConfigurationAsync(FeatureContext featureContext)
         {
             var functionConfiguration = new FunctionConfiguration();
@@ -33,6 +33,13 @@ namespace Corvus.SpecFlow.Extensions.Demo.AzureFunctionsTesting
             featureContext.Set(functionConfiguration);
 
             return StartFunctionsAsync(featureContext);
+        }
+
+        [AfterScenario("usingDemoFunctionPerFeature", "usingDemoFunctionPerFeatureWithAdditionalConfiguration")]
+        public static void WriteOutput(FeatureContext featureContext)
+        {
+            FunctionsController functionsController = featureContext.Get<FunctionsController>();
+            functionsController.GetFunctionsOutput().WriteAllToConsoleAndClear();
         }
 
         [AfterFeature("usingDemoFunctionPerFeature", "usingDemoFunctionPerFeatureWithAdditionalConfiguration")]

--- a/Solutions/Corvus.SpecFlow.Extensions.DemoFunction/host.json
+++ b/Solutions/Corvus.SpecFlow.Extensions.DemoFunction/host.json
@@ -4,5 +4,10 @@
     "http": {
       "routePrefix": ""
     }
+  },
+  "logging": {
+    "logLevel": {
+      "default": "Debug"
+    }
   }
 }

--- a/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/IProcessOutput.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/IProcessOutput.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="IProcessOutput.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.SpecFlow.Extensions
+{
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Provides access to the output for a process.
+    /// </summary>
+    public interface IProcessOutput
+    {
+        /// <summary>
+        /// Gets the <see cref="ProcessStartInfo"/> for the process being monitored.
+        /// </summary>
+        ProcessStartInfo ProcessStartInfo { get; }
+
+        /// <summary>
+        ///     Gets the standard output produced so far by this process.
+        /// </summary>
+        string StandardOutputText { get; }
+
+        /// <summary>
+        ///     Gets the standard error output produced so far by this process.
+        /// </summary>
+        string StandardErrorText { get; }
+
+        /// <summary>
+        ///     Clears the output and error buffers.
+        /// </summary>
+        void ClearAllOutput();
+    }
+}

--- a/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/Internal/ProcessOutputHandler.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/Internal/ProcessOutputHandler.cs
@@ -105,13 +105,13 @@ namespace Corvus.SpecFlow.Extensions.Internal
                     if (this.standardOutput.Length > 0)
                     {
                         this.standardOutput.Clear();
-                        this.standardOutput.AppendLine($"Log cleared at {DateTime.UtcNow.ToString()}");
+                        this.standardOutput.Append("Output cleared at ").AppendLine(DateTime.UtcNow.ToString());
                     }
 
                     if (this.standardError.Length > 0)
                     {
                         this.standardError.Clear();
-                        this.standardError.AppendLine($"Log cleared at {DateTime.UtcNow.ToString()}");
+                        this.standardError.Append("Output cleared at ").AppendLine(DateTime.UtcNow.ToString());
                     }
                 }
             }

--- a/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/Internal/ProcessOutputHandler.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/Internal/ProcessOutputHandler.cs
@@ -12,7 +12,7 @@ namespace Corvus.SpecFlow.Extensions.Internal
     /// <summary>
     ///     Provides simplified access to a process's text output.
     /// </summary>
-    public class ProcessOutputHandler
+    public class ProcessOutputHandler : IProcessOutput
     {
         /// <summary>
         ///     Provides the task for <see cref="ExitCode"/>, enabling users of this class to
@@ -58,6 +58,11 @@ namespace Corvus.SpecFlow.Extensions.Internal
         public Process Process { get; }
 
         /// <summary>
+        ///     Gets the <see cref="ProcessStartInfo"/> for the process being monitored.
+        /// </summary>
+        public ProcessStartInfo ProcessStartInfo => this.Process.StartInfo;
+
+        /// <summary>
         ///     Gets a task that produces the exit code of the process once it completes.
         /// </summary>
         public Task<int> ExitCode => this.exitCodeCompletionSource.Task;
@@ -86,6 +91,28 @@ namespace Corvus.SpecFlow.Extensions.Internal
                 lock (this.standardError)
                 {
                     return this.standardError.ToString();
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void ClearAllOutput()
+        {
+            lock (this.standardOutput)
+            {
+                lock (this.standardError)
+                {
+                    if (this.standardOutput.Length > 0)
+                    {
+                        this.standardOutput.Clear();
+                        this.standardOutput.AppendLine($"Log cleared at {DateTime.UtcNow.ToString()}");
+                    }
+
+                    if (this.standardError.Length > 0)
+                    {
+                        this.standardError.Clear();
+                        this.standardError.AppendLine($"Log cleared at {DateTime.UtcNow.ToString()}");
+                    }
                 }
             }
         }

--- a/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/ProcessOutputExtensions.cs
+++ b/Solutions/Corvus.SpecFlow.Extensions/Corvus/SpecFlow/Extensions/ProcessOutputExtensions.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="ProcessOutputExtensions.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.SpecFlow.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extension methods for the <see cref="IProcessOutput"/> interface.
+    /// </summary>
+    public static class ProcessOutputExtensions
+    {
+        /// <summary>
+        /// Writes the process StdOut and StdErr to the console, then clears both output buffers.
+        /// </summary>
+        /// <param name="output">The <see cref="IProcessOutput"/> to write.</param>
+        public static void WriteToConsoleAndClear(this IProcessOutput output)
+        {
+            string name =
+                $"{output.ProcessStartInfo.FileName} {output.ProcessStartInfo.Arguments}, working directory {output.ProcessStartInfo.WorkingDirectory}";
+
+            Console.WriteLine($"\nStdOut for process {name}:");
+            Console.WriteLine(output.StandardOutputText);
+            Console.WriteLine();
+
+            string stdErr = output.StandardErrorText;
+
+            if (!string.IsNullOrEmpty(stdErr))
+            {
+                Console.WriteLine($"\nStdErr for process {name}:");
+                Console.WriteLine(stdErr);
+                Console.WriteLine();
+            }
+
+            output.ClearAllOutput();
+        }
+
+        /// <summary>
+        /// Writes the process StdOut and StdErr to the console, then clears both output buffers for each supplied
+        /// <see cref="IProcessOutput"/>.
+        /// </summary>
+        /// <param name="outputs">The list of <see cref="IProcessOutput"/> to write.</param>
+        public static void WriteAllToConsoleAndClear(this IEnumerable<IProcessOutput> outputs)
+        {
+            foreach (IProcessOutput output in outputs)
+            {
+                output.WriteToConsoleAndClear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
When using the functions bindings, output from the function is automatically written to the Console  when the function is killed. When using the step bindings or the `FunctionsController` in Before/After Scenario hooks, this output is automatically captured by SpecFlow and added to the output for the spec.

If using the `FunctionsController` in Before/After Feature hooks, the functions are killed after all the scenarios have finished executing. This means that the output from the functions is not captured, making it difficult to debug when function calls fail.

I've extended the `FunctionsController` to allow access to the function output via a new interface `IProcessOutput` on the `ProcessOutputHandler`, which provides for reading the `StandardOutputText` and `StandardErrorText` of the `ProcessOutputHandler` and also for clearing output - this is useful when writing the output at the end of a scenario to stop the output from previous scenarios being repeated. 

An example of this in use can be seen in `Corvus.SpecFlow.Extensions.Demo.AzureFunctionsTesting.DemoFunctionPerFeatureHooks`, in the `WriteOutput` method.